### PR TITLE
Rsync does not check emptyness of "became" option

### DIFF
--- a/src/Utility/Rsync.php
+++ b/src/Utility/Rsync.php
@@ -67,7 +67,7 @@ class Rsync
         if ($connectionOptions !== '') {
             $options = array_merge($options, ['-e', "ssh $connectionOptions"]);
         }
-        if ($host->has("become")) {
+        if ($host->has('become') && !empty($host->get('become'))) {
             $options = array_merge($options, ['--rsync-path', "sudo -H -u {$host->get('become')} rsync"]);
         }
         if (!is_array($source)) {


### PR DESCRIPTION
https://github.com/deployphp/deployer/discussions/4073

- [ ] Bug fix #4073?

      Please, regenerate docs by running next command:
      $ php bin/docgen
